### PR TITLE
Adding the current volume feature and some changes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-This script mute spotify when there is a playing advertisement and only works on MacOS
+# Spotify Ad Muter
+This script mute Spotify when there is a playing advertisement and only works on macOS.
 
-spotify in newer versions will not allow to mute in advertisement, you can't even set the volume to zero, so I set the volume to 1 😁
-then after advertisement it will be on max volume (you can set the max volume in arguments).
+In newer versions, Spotify does not allow users to shut down the advertisements` sound by setting the volume to zero. So, this script is going to set the volume to the minimum value, which is 1.
+Also, after the advertisement, it is going to set the volume on the previous value or a max volume, which you can set it as an environmental variable.
 
-you should have `node.js` and `npm` installed
+## Usage
 
-clone then run
+You should have `Node.js` and `npm` installed.
+
+Clone then run
 `npm install`
 
-then run
-
+Then run the script
 `npm start`
 
-for max volume you can set it this way
-
+For the max volume, you can set it this way
 `npm start 70`
 
-volume can be from 0 to 100
+## Tips
+* Volume can be from 0 to 100

--- a/index.js
+++ b/index.js
@@ -2,14 +2,18 @@ const spotify = require("spotify-node-applescript");
 
 let lastTrackName = "";
 let maxVol = process.argv[2] || 100;
-
+let currentVol = 0;
 function check() {
   function checkIn(time) {
     console.log("CheckIn", `${time} ms`);
     setTimeout(() => check(), time);
   }
 
-  spotify.getTrack(function(err, track) {
+  spotify.getState(function (err, state) {
+    currentVol = state.volume
+  });
+
+  spotify.getTrack(function (err, track) {
     if (err) {
       console.log("Error on getting Track: ");
       console.log(err);
@@ -23,7 +27,11 @@ function check() {
       if (track.name === "Advertisement" || track.name === "Spotify") {
         spotify.setVolume(1);
       } else {
-        spotify.setVolume(maxVol);
+        if (currentVol) {
+          spotify.setVolume(currentVol);
+        } else {
+          spotify.setVolume(maxVol);
+        }
       }
     }
     spotify.getState((err, state) => {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const spotify = require("spotify-node-applescript");
 
 let lastTrackName = "";
 let maxVol = process.argv[2] || 100;
-let currentVol = 0;
+let currentVol = -1;
 function check() {
   function checkIn(time) {
     console.log("CheckIn", `${time} ms`);
@@ -27,7 +27,7 @@ function check() {
       if (track.name === "Advertisement" || track.name === "Spotify") {
         spotify.setVolume(1);
       } else {
-        if (currentVol) {
+        if (currentVol >= 0) {
           spotify.setVolume(currentVol);
         } else {
           spotify.setVolume(maxVol);


### PR DESCRIPTION
At the moment script is going to set the volume to the max value, I've tried to add the current volume feature. So, after ads script is going to set the volume on the previous value.
Unfortyultly, as Spotify didn't show me any ads, I couldn't test it on my device

Also, I've tried to change some stuff in the readme.

If you think they're okay you can merge it.